### PR TITLE
Update FTP URLs to HTTPS

### DIFF
--- a/_posts/2017-08-29-How-to-set-up.md
+++ b/_posts/2017-08-29-How-to-set-up.md
@@ -6,15 +6,15 @@ order: 0
 ---
 #### 1. Download IgBlast program
 
-IgBlast program can be downloaded from ([https://ftp.ncbi.nih.gov/blast/executables/igblast/release/LATEST](ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/LATEST) ).  We provide pre-compiled programs for Linux, Windows, MacOs as well as source code for you to build on your own platform. 
+IgBlast program can be downloaded from <https://ftp.ncbi.nih.gov/blast/executables/igblast/release/LATEST>.  We provide pre-compiled programs for Linux, Windows, MacOs as well as source code for you to build on your own platform. 
 
-Note, for versions prior to 1.13.0 only, you also need to download the old internal_data and optional_file folders from [https://ftp.ncbi.nih.gov/blast/executables/igblast/release/](ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/).  We strongly encourage you to get the latest IgBlast version with built-in internal_data and optional_file.
+Note, for versions prior to 1.13.0 only, you also need to download the old internal_data and optional_file folders from <https://ftp.ncbi.nih.gov/blast/executables/igblast/release/>.  We strongly encourage you to get the latest IgBlast version with built-in internal_data and optional_file.
 
 #### 2. Get blast database for germline V, D, and J gene sequences.  
 
 IgBlast allows you to search any germline databases of your choice (using -germline_db_V, -germline_db_J and -germline_db_D options).
 
-The NCBI mouse germline gene databases (i.e., mouse_gl_V, etc.) are supplied on our ftp site ([https://ftp.ncbi.nih.gov/blast/executables/igblast/release/database/](ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/database/).  Also see [https://www.ncbi.nlm.nih.gov/igblast/](https://www.ncbi.nlm.nih.gov/igblast/) about database details).
+The NCBI mouse germline gene databases (i.e., mouse_gl_V, etc.) are supplied on our ftp site (<https://ftp.ncbi.nih.gov/blast/executables/igblast/release/database/>.  Also see <https://www.ncbi.nlm.nih.gov/igblast/> about database details).
   
 To search IMGT germline sequences, you need to download them from IMGT web site 
 ([http://www.imgt.org/vquest/refseqh.html#VQUEST](http://www.imgt.org/vquest/refseqh.html#VQUEST) ).  You need to download all V, D and J sequences for whatever organisms you are interested in.  Combine all V, all D and all J sequences, respectively, into separate files (i.e., one file for all V sequences, one for all D sequences and one file all for J sequences).  After you have downloaded the sequences, invoke our utility tool edit_imgt_file.pl (in the bin directory in the IgBlast release package) to process these sequences (i.e., to change the long IMGT definition lines to germline gene names only).  For example:


### PR DESCRIPTION
These three URLs were shown as https:// but actually still started with ftp://.  I think the original intent (in 29f62e76277161971e300b205918ffeca86d6adf) was to use HTTPS instead since most browsers have dropped support for FTP.